### PR TITLE
Feat/set root url

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ No modules.
 | <a name="input_platform_version"></a> [platform\_version](#input\_platform\_version) | The ECS Fargate version to run Grafana on. | `string` | `"LATEST"` | no |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | The list of private subnet IDs. | `list(any)` | n/a | yes |
 | <a name="input_public_subnet_ids"></a> [public\_subnet\_ids](#input\_public\_subnet\_ids) | The list of public subnet IDs. | `list(any)` | n/a | yes |
+| <a name="input_root_url"></a> [root\_url](#input\_root\_url) | The root URL for Grafana, if not set it might cause issues with OAuth. | `string` | `"%(protocol)s://%(domain)s:%(http_port)s/"` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | The name of the ECS service. | `string` | `"grafana"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID in which to deploy the resources. | `string` | n/a | yes |
 

--- a/container-definition/container-definition.json
+++ b/container-definition/container-definition.json
@@ -27,6 +27,12 @@
     ],
     "secrets": [],
     "volumesFrom": [],
-    "essential": true
+    "essential": true,
+    "environment": [
+      {
+          "name": "GF_SERVER_ROOT_URL",
+          "value": ${root_url}
+      }
+    ]
   }
 ]

--- a/container-definition/container-definition.json
+++ b/container-definition/container-definition.json
@@ -31,7 +31,7 @@
     "environment": [
       {
           "name": "GF_SERVER_ROOT_URL",
-          "value": ${root_url}
+          "value": "${root_url}"
       }
     ]
   }

--- a/ecs.tf
+++ b/ecs.tf
@@ -26,6 +26,7 @@ locals {
     cpu                       = var.cpu
     memory                    = var.memory
     container_port            = var.container_port
+    root_url                  = var.root_url
   })
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "container_port" {
   default     = 3000
 }
 
+variable "root_url" {
+  description = "The root URL for Grafana, if not set it might cause issues with OAuth."
+  type        = string
+  default     = "%(protocol)s://%(domain)s:%(http_port)s/"
+}
+
 variable "cloudwatch_log_group_name" {
   description = "The name of the Cloudwatch log group where the application will send logs to."
   type        = string


### PR DESCRIPTION
This allows the module to set the `GF_SERVER_ROOT_URL` env variable for Grafana. This should solve the issue with Oauth providers not being able to authenticate.